### PR TITLE
Update pymodbus dependency version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pymodbus>=3.7.4
+pymodbus>=3.7.4,<3.10
 SungrowModbusTcpClient>=0.1.5
 SungrowModbusWebClient>=0.3.2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     url="https://github.com/bohdan-s/SungrowClient",
     packages=setuptools.find_packages(),
     install_requires=[
-        'pymodbus>=3.7.4',
+        'pymodbus>=3.7.4,<3.10',
         'SungrowModbusTcpClient>=0.1.5',
         'SungrowModbusWebClient>=0.3.2',
     ],


### PR DESCRIPTION
- Restrict pymodbus version to <3.10 in both requirements.txt and setup.py
- Ensures compatibility with SungrowModbusTcpClient